### PR TITLE
Adding licence information to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "object-stream",
   "version": "0.0.1",
+  "license": "MIT",
   "author": {
     "name": "Nicolas Mercier"
   },
@@ -9,7 +10,7 @@
     "stream",
     "streams2"
   ],
-  "engines" : {
+  "engines": {
     "node": ">=0.10"
   },
   "scripts": {


### PR DESCRIPTION
Hi,
we want to use [parquetjs](https://github.com/ironSource/parquetjs) (which is depending `object-stream`) in one of our projects.
Our organization flags packages with no specified license and does not allow us to use them, preventing us from consuming `parquetjs`.
According to the README, this package is published under the MIT license - this pull request just makes it official ;)
